### PR TITLE
Fix for Issue#7: requre to require_once

### DIFF
--- a/tripal_file.module
+++ b/tripal_file.module
@@ -10,8 +10,8 @@
 
 // EXPLANATION: include any files needed for this module.  That includes any
 // API file, the theme file, or include files.
-require('api/tripal_file.api.inc');
-require('theme/tripal_file.theme.inc');
+require_once('api/tripal_file.api.inc');
+require_once('theme/tripal_file.theme.inc');
 
 
 /**


### PR DESCRIPTION
I think that this simple change resolves Issue #7 
in ```tripal_file.module```, change ```require``` to ```require_once```

The stray ```<?php``` on enabling the module no longer appears.
```
$ drush pm-enable tripal_file
The following extensions will be enabled: tripal_file
Do you really want to continue? (y/n): y
tripal_file was enabled successfully.
```