### PR TITLE
Fix for Issue#11: schema__itemlocation schema__license_formatter

### DIFF
--- a/includes/TripalFields/schema__itemlocation/schema__itemlocation.inc
+++ b/includes/TripalFields/schema__itemlocation/schema__itemlocation.inc
@@ -161,12 +161,16 @@ class schema__itemlocation extends ChadoField {
       $fileloc_linkers = $record->fileloc;
       if ($fileloc_linkers) {
         foreach ($fileloc_linkers as $i => $fileloc) {
+          $filesize = $fileloc->size;  // integer or empty string
+          if (preg_match('/^\d+$/', $filesize)) {
+            $filesize = tripal_format_bytes($filesize);
+          }
           $entity->{$field_name}['und'][$i] = [
             'value' => [
               $uri_term => file_create_url($fileloc->uri),
               $rank_term => $fileloc->rank,
               $md5_term => $fileloc->md5checksum,
-              $size_term => tripal_format_bytes($fileloc->size),
+              $size_term => $filesize,
             ],
             'chado-fileloc__fileloc_id' => $fileloc->fileloc_id,
             'chado-fileloc__file_id' => $fileloc->file_id->file_id,

--- a/includes/TripalFields/schema__license/schema__license_formatter.inc
+++ b/includes/TripalFields/schema__license/schema__license_formatter.inc
@@ -61,6 +61,7 @@ class schema__license_formatter extends ChadoFieldFormatter {
       'sticky' => FALSE,
       'caption' => "",
       'colgroups' => [],
+      'empty' => 'There is no license for this file.',
     ];
     $content = theme_table($table);
 

--- a/tripal_file.module
+++ b/tripal_file.module
@@ -172,7 +172,7 @@ function tripal_file_bundle_instances_info($entity_type, $bundle) {
       'entity_type' => 'TripalEntity',
       'bundle' => $bundle->name,
       'label' => 'References',
-      'description' => 'Content that referecnes this file.',
+      'description' => 'Content that references this file.',
       'required' => FALSE,
       'settings' => [
         'auto_attach' => FALSE,


### PR DESCRIPTION
Fix for Issue #11 

The following two warnings appear on a file page:

Warning: A non-numeric value encountered in tripal_format_bytes() (line 153 of /var/www/2020-02-18/drupal-7.69/sites/all/modules/tripal/tripal/api/tripal.files.api.inc).

Notice: Undefined index: empty in theme_table() (line 2003 of /var/www/2020-02-18/drupal-7.69/includes/theme.inc).Notice: Undefined index: empty in theme_table() (line 2003 of /var/www/2020-02-18/drupal-7.69/includes/theme.inc).

The first warning appears when the file is a URL and the file size is a null string in schema__itemlocation.inc

The second notice appears because a value for ['empty'] is not defined in schema__license_formatter.inc

One stray typo corrected also.