### PR TITLE
Issue #5 Allow public:// prefix for local unmanaged files

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -149,7 +149,15 @@ If you already have the file uploaded to Tripal then it will automatically appea
 
 .. image:: ./file_add2.png
 
-Otherwise you can provide a remote URL for the file.
+Otherwise you can provide a remote URL for the file. If you have files on your site that are not
+managed by Tripal, you can use a URL here that points to the full path on your site. In both of these
+cases file size and md5 checksum cannot be automatically generated. Alternatively, you can use
+a public:// prefix for local files, in which case the file size and md5 checksum can be
+automatically included. As an example, you might upload a file to your local filesystem in the
+directory
+`sites/default/files/bulk_data/`
+and then you could specify a Remote URL of
+`public://bulk_data/Citrus_sinensis-scaffold00001.fasta`
 
 .. note::
 

--- a/includes/TripalFields/schema__itemlocation/schema__itemlocation.inc
+++ b/includes/TripalFields/schema__itemlocation/schema__itemlocation.inc
@@ -165,9 +165,14 @@ class schema__itemlocation extends ChadoField {
           if (preg_match('/^\d+$/', $filesize)) {
             $filesize = tripal_format_bytes($filesize);
           }
+          // ftp:// won't pass through file_create_url()
+          $uri = file_create_url($fileloc->uri);
+          if (!$uri) {
+            $uri = $fileloc->uri;
+          }
           $entity->{$field_name}['und'][$i] = [
             'value' => [
-              $uri_term => file_create_url($fileloc->uri),
+              $uri_term => $uri,
               $rank_term => $fileloc->rank,
               $md5_term => $fileloc->md5checksum,
               $size_term => $filesize,

--- a/includes/TripalFields/schema__itemlocation/schema__itemlocation_formatter.inc
+++ b/includes/TripalFields/schema__itemlocation/schema__itemlocation_formatter.inc
@@ -53,7 +53,8 @@ class schema__itemlocation_formatter extends ChadoFieldFormatter {
 
          // Check if the base URL of the file is from this site.
          global $base_url;
-         if ($base_url == 'http://' . $url_parts['host']) {
+         if ( ($base_url == 'http://' . $url_parts['host']) or
+              ($base_url == 'https://' . $url_parts['host']) ) {
            $source = variable_get('site_name');
          }
        }

--- a/includes/TripalFields/schema__itemlocation/schema__itemlocation_widget.inc
+++ b/includes/TripalFields/schema__itemlocation/schema__itemlocation_widget.inc
@@ -117,10 +117,10 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
     $unmanaged = $form_state['values'][$field_name]['und'][$delta]['unmanaged'];
     $managed = $form_state['values'][$field_name]['und'][$delta]['managed'];
     if ($unmanaged and $managed) {
-      form_set_error($field_name . '][und]['. $delta . '][remote', "For the file location, please provide only a URL or Tripal managed file but not both.");
+      form_set_error($field_name . '][und]['. $delta . '][unmanaged', "For the file location, please provide only a URL or Tripal managed file but not both.");
     }
     if (!$unmanaged and !$managed and $delta == 0) {
-      form_set_error($field_name . '][und]['. $delta . '][remote', "Please specify a location as a URL or a Tripal managed file.");
+      form_set_error($field_name . '][und]['. $delta . '][unmanaged', "Please specify a location as a URL or a Tripal managed file.");
     }
 
     // If the file is local then get the size, and get the md5 checksum if one exists.

--- a/includes/TripalFields/schema__itemlocation/schema__itemlocation_widget.inc
+++ b/includes/TripalFields/schema__itemlocation/schema__itemlocation_widget.inc
@@ -64,7 +64,7 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
     ];
 
     // Set the remote or local value based on what the value of the
-    // fieloc.uri field.
+    // fileloc.uri field.
     if ($uri) {
       if (preg_match('/^(http|ftp)/', $uri)) {
         $remote = $uri;
@@ -75,6 +75,10 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
         $query->distinct();
         $query->condition('FM.uri', $uri);
         $local = $query->execute()->fetchField();
+        // we can also use the public:// prefix with local files not managed by tripal
+        if (!$local) {
+          $remote = $uri;
+        }
       }
     }
 
@@ -121,16 +125,38 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
       form_set_error($field_name . '][und]['. $delta . '][remote', "Please specify a location as a URL or a Tripal managed file.");
     }
 
-    // If the file is local then get the size and md5 checksum if one exists.
+    // If the file is local then get the size, and get the md5 checksum if one exists.
+    $local_file_path = '';
     if ($local) {
       $local_file = file_load($local);
       $local_file_path = drupal_realpath($local_file->uri);
-      if (file_exists($local_file_path .'.md5')) {
-        $md5 = file_get_contents($local_file_path .'.md5');
-        $form_state['values'][$field_name]['und'][$delta]['chado-fileloc__md5checksum'] = $md5;
+      $which_element = 'local';
+    }
+    // A remote url here with a public:// prefix is a local file, but not managed by
+    // tripal. We can still look up file size and checksum the same as managed files.
+    elseif ( ($remote) and (preg_match('/^public:\/\//', $remote)) ) {
+      $local_file_path = drupal_realpath($remote);
+      $which_element = 'remote';
+    }
+    if ($local_file_path) {
+      if (file_exists($local_file_path)) {
+        if (file_exists($local_file_path .'.md5')) {
+          // substr here because non-managed md5 files might also contain a file name after
+          // the checksum if generated using the md5sum program, and do extra verification.
+          $md5 = substr(file_get_contents($local_file_path .'.md5'), 0, 32);
+          if (preg_match('/^[A-Za-z0-9]{32}$/', $md5)) {
+            $form_state['values'][$field_name]['und'][$delta]['chado-fileloc__md5checksum'] = $md5;
+          }
+          else {
+            form_set_error($field_name . '][und]['. $delta . '][' . $which_element, "The file \"${local_file_path}.md5\" contains an invalid md5 checksum.");
+          }
+        }
+        $size = filesize($local_file_path);
+        $form_state['values'][$field_name]['und'][$delta]['chado-fileloc__size'] = $size;
       }
-      $size = filesize($local_file_path);
-      $form_state['values'][$field_name]['und'][$delta]['chado-fileloc__size'] = $size;
+      else {
+        form_set_error($field_name . '][und]['. $delta . '][' . $which_element, "\"$remote\" does not exist on the local filesystem.");
+      }
     }
 
     // If the user re-ordered the items then set the rank to match.

--- a/includes/TripalFields/schema__itemlocation/schema__itemlocation_widget.inc
+++ b/includes/TripalFields/schema__itemlocation/schema__itemlocation_widget.inc
@@ -20,8 +20,8 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
     $uri = '';
     $md5 = NULL;
     $size = NULL;
-    $remote = '';
-    $local = '';
+    $unmanaged = '';
+    $managed = '';
     $rank = $delta;
 
     // If the field already has a value then it will come through the $items
@@ -66,27 +66,25 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
     // Set the remote or local value based on what the value of the
     // fileloc.uri field.
     if ($uri) {
-      if (preg_match('/^(http|ftp)/', $uri)) {
-        $remote = $uri;
-      }
-      else {
-        $query = db_select('file_managed', 'FM');
-        $query->fields('FM', ['fid']);
-        $query->distinct();
-        $query->condition('FM.uri', $uri);
-        $local = $query->execute()->fetchField();
-        // we can also use the public:// prefix with local files not managed by tripal
-        if (!$local) {
-          $remote = $uri;
-        }
+      // test if this is a file managed by Tripal e.g. public://tripal/users/1/filename
+      $query = db_select('file_managed', 'FM');
+      $query->fields('FM', ['fid']);
+      $query->distinct();
+      $query->condition('FM.uri', $uri);
+      $managed = $query->execute()->fetchField();
+      
+      // if not a managed file, it can be a remote url with http:// https:// or ftp://
+      // prefix or a local unmanaged file with public:// prefix
+      if (!$managed) {
+        $unmanaged = $uri;
       }
     }
 
-    $widget['remote'] = [
+    $widget['unmanaged'] = [
       '#type' => 'textfield',
-      '#title' => t('Remote URL'),
-      '#description' => t('If the file is not managed by Drupal or Tripal then enter the full URL to the file. Use this field if the file is shared publicly on this same web server but not managed by Drupal or Tripal.'),
-      '#default_value' => $remote,
+      '#title' => t('URL'),
+      '#description' => t('If the file is not managed by Drupal or Tripal then enter the full URL to the file. Use this field with public:// prefix if the file is shared publicly on this same web server but not managed by Drupal or Tripal.'),
+      '#default_value' => $unmanaged,
       '#maxlength' => 100000,
     ];
 
@@ -97,11 +95,11 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
     foreach ($files as $fid => $file) {
       $options[$fid] = $file->filename;
     }
-    $widget['local'] = [
+    $widget['managed'] = [
       '#type' => 'select',
       '#title' => t('Tripal Managed File'),
       '#options' => $options,
-      '#default_value' => $local,
+      '#default_value' => $managed,
       '#description' => t('Please select a file.'),
     ];
 
@@ -116,30 +114,39 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
     $field_name = $this->field['field_name'];
 
     // Perform validation of form elements.
-    $remote = $form_state['values'][$field_name]['und'][$delta]['remote'];
-    $local = $form_state['values'][$field_name]['und'][$delta]['local'];
-    if ($remote and $local) {
+    $unmanaged = $form_state['values'][$field_name]['und'][$delta]['unmanaged'];
+    $managed = $form_state['values'][$field_name]['und'][$delta]['managed'];
+    if ($unmanaged and $managed) {
       form_set_error($field_name . '][und]['. $delta . '][remote', "For the file location, please provide only a URL or Tripal managed file but not both.");
     }
-    if (!$remote and !$local and $delta == 0) {
+    if (!$unmanaged and !$managed and $delta == 0) {
       form_set_error($field_name . '][und]['. $delta . '][remote', "Please specify a location as a URL or a Tripal managed file.");
     }
 
     // If the file is local then get the size, and get the md5 checksum if one exists.
     $local_file_path = '';
-    if ($local) {
-      $local_file = file_load($local);
+    if ($managed) {
+      $which_element = 'managed';
+      $local_file = file_load($managed);
       $local_file_path = drupal_realpath($local_file->uri);
-      $which_element = 'local';
     }
-    // A remote url here with a public:// prefix is a local file, but not managed by
-    // tripal. We can still look up file size and checksum the same as managed files.
-    elseif ( ($remote) and (preg_match('/^public:\/\//', $remote)) ) {
-      $local_file_path = drupal_realpath($remote);
-      $which_element = 'remote';
+    // A URL here with a public:// prefix is a local file, but not managed by tripal.
+    // We can look up file size and checksum for all local files whether managed or not.
+    elseif ($unmanaged) {
+      $which_element = 'unmanaged';
+      if (preg_match('#^public://#', $unmanaged)) {
+        $local_file_path = drupal_realpath($unmanaged);
+        if (!$local_file_path) {
+          form_set_error($field_name . '][und]['. $delta . '][' . $which_element, "The file \"$unmanaged\" does not exist on the local filesystem.");
+        }
+      }
+      // remote URLs get no validation beyond having a recognized scheme
+      elseif (!preg_match('#^https?://|ftp://#i', $unmanaged)) {
+        form_set_error($field_name . '][und]['. $delta . '][' . $which_element, "Invalid URL \"$unmanaged\": must have http:// https:// ftp:// or public:// prefix.");
+      }
     }
     if ($local_file_path) {
-      if (file_exists($local_file_path)) {
+       if (file_exists($local_file_path)) {
         if (file_exists($local_file_path .'.md5')) {
           // substr here because non-managed md5 files might also contain a file name after
           // the checksum if generated using the md5sum program, and do extra verification.
@@ -155,7 +162,7 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
         $form_state['values'][$field_name]['und'][$delta]['chado-fileloc__size'] = $size;
       }
       else {
-        form_set_error($field_name . '][und]['. $delta . '][' . $which_element, "\"$remote\" does not exist on the local filesystem.");
+        form_set_error($field_name . '][und]['. $delta . '][' . $which_element, "The file \"$local_file_path\" does not exist on the local filesystem.");
       }
     }
 
@@ -165,11 +172,11 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
 
 
     // Set the File URI value according to the user's selection.
-    if ($remote) {
-      $form_state['values'][$field_name]['und'][$delta]['chado-fileloc__uri'] = $remote;
-    }
-    elseif ($local) {
-      $file = file_load($local);
+    if ($unmanaged) {
+      $form_state['values'][$field_name]['und'][$delta]['chado-fileloc__uri'] = $unmanaged;
+     }
+    elseif ($managed) {
+      $file = file_load($managed);
       $form_state['values'][$field_name]['und'][$delta]['chado-fileloc__uri'] = $file->uri;
     }
     // If no file is selected then clear out all values but the Pkey so the

--- a/includes/TripalFields/schema__itemlocation/schema__itemlocation_widget.inc
+++ b/includes/TripalFields/schema__itemlocation/schema__itemlocation_widget.inc
@@ -174,7 +174,7 @@ class schema__itemlocation_widget extends ChadoFieldWidget {
     // Set the File URI value according to the user's selection.
     if ($unmanaged) {
       $form_state['values'][$field_name]['und'][$delta]['chado-fileloc__uri'] = $unmanaged;
-     }
+    }
     elseif ($managed) {
       $file = file_load($managed);
       $form_state['values'][$field_name]['und'][$delta]['chado-fileloc__uri'] = $file->uri;

--- a/tripal_file.module
+++ b/tripal_file.module
@@ -172,7 +172,7 @@ function tripal_file_bundle_instances_info($entity_type, $bundle) {
       'entity_type' => 'TripalEntity',
       'bundle' => $bundle->name,
       'label' => 'References',
-      'description' => 'Content that referecnes this file.',
+      'description' => 'Content that references this file.',
       'required' => FALSE,
       'settings' => [
         'auto_attach' => FALSE,

--- a/tripal_file.module
+++ b/tripal_file.module
@@ -91,7 +91,7 @@ function tripal_file_bundle_fields_info($entity_type, $bundle) {
 }
 
 /**
- * Impelments hook_create_tripalfield_instance().
+ * Implements hook_create_tripalfield_instance().
  *
  * This is a Tripal defined hook that supports integration with the
  * TripalEntity field.
@@ -172,7 +172,7 @@ function tripal_file_bundle_instances_info($entity_type, $bundle) {
       'entity_type' => 'TripalEntity',
       'bundle' => $bundle->name,
       'label' => 'References',
-      'description' => 'Content that references this file.',
+      'description' => 'Content that referecnes this file.',
       'required' => FALSE,
       'settings' => [
         'auto_attach' => FALSE,


### PR DESCRIPTION
This partially addresses issue #5 and issue #4 by allowing files already on the filesystem, but not managed by Tripal, to be linked using a public:// prefix.
This allows the files to have size and md5 checksum values populated.
For example I tested with both a URL and a file in an existing heirarchy
```
https://static-content.springer.com/esm/art%3A10.1186%2F1471-2164-12-389/MediaObjects/12864_2011_3596_MOESM2_ESM.FASTA
public://bulk_data/carrotomics/sequence/est-assembly1/12864_2011_3596_MOESM2_ESM.FASTA.gz
```
![20210310_downloadexample](https://user-images.githubusercontent.com/8419404/110712535-afed3c00-81c6-11eb-8375-5df1a5ec2d14.png)
