### PR TITLE
Fix for Issue#14: sio__references_file

### DIFF
--- a/includes/TripalFields/sio__references_file/sio__references_file.inc
+++ b/includes/TripalFields/sio__references_file/sio__references_file.inc
@@ -182,7 +182,7 @@ class sio__references_file extends ChadoField {
           // so... we'll do the best we can.
           $entity->{$field_name}['und'][$delta]['value'] = [];
 
-          // If this records is also a published entity then include that.
+          // If this record is also a published entity then include that.
           $ref_type = NULL;
           if (property_exists($record, 'entity_id') and !empty($record->entity_id)) {
             [$entity_id, $ref_type] = explode('|', $record->entity_id);
@@ -209,15 +209,14 @@ class sio__references_file extends ChadoField {
           // If this is the organism table then we will create the name
           // specially.
           if (property_exists($record, 'genus')) {
-            $name = '<i>' . $record->genus . ' ' . $record->species . '</i>';
-            if (property_exists($record, 'infraspecific_name')) {
-              if ($record->$fkleft->type_id) {
-                $name .= ' ' . $record->type_name;
-              }
-              $name .= ' ' . $record->infraspecific_name;
+            $name = $record->genus . ' ' . $record->species;
+            if (function_exists('chado_get_organism_scientific_name')) {
+              $name = chado_get_organism_scientific_name(chado_get_organism(['organism_id' => $record->organism_id], []));
             }
             $entity->{$field_name}['und'][$delta]['value']['schema:name'] = $name;
-            $entity->{$field_name}['und'][$delta]['value']['rdfs:type'] = $ref_type->name;
+            // revert back to $ref_type of 'Organism' because the type_id will be
+            // for the infraspecific type
+            $entity->{$field_name}['und'][$delta]['value']['rdfs:type'] = $ref_type;
           }
           $delta++;
         }


### PR DESCRIPTION
Changes to address issue #14 and one typo

**Before**
![error](https://user-images.githubusercontent.com/8419404/111076217-6e57dc00-84b9-11eb-92b0-ef960587be44.png)
![before](https://user-images.githubusercontent.com/8419404/111075936-2f755680-84b8-11eb-9f59-7b7a01283361.png)
**After**
![after](https://user-images.githubusercontent.com/8419404/111075948-369c6480-84b8-11eb-8ada-22a14d0ace6f.png)

1. The italic HTML tags ```<i> </i>``` were removed because they were for some reason being stripped off anyway and not affecting the displayed value.
2. Use the super-handy ```chado_get_organism_scientific_name()``` function to handle infraspecific nomenclature. I think this is a newer function so for some Tripal sites this may not be present, thus the fallback of genus + species is retained.
3. The value for 'rdfs:type' will have been generated earlier, but in this case it will be for the infraspecific type _e.g._ "subspecies", so we need to revert back to the value that was stored earlier in ```$ref_type``` (which is a string not an object, thus one of the notices) which will be "Organism".
