### PR TITLE
Fix for issue #17

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -246,7 +246,7 @@ The *fileprop* table holds the properties or metadata about files. The CV term i
 
 The fileloc Table
 +++++++++++++++++
-The *fileloc* table indicates where files can be downloaded. The *uri* column must contain the URI of the file. Even local files have a URI. For example a Drupal URI usually has a  *public://* URI prefix. For example: ```public://tripal/users/1/Citrus_sinensis-scaffold0.fasta```. When a file has more than one location to download the can be ordered by setting the *rank* column.  The Tripal file module automatically fills in the *size* and *md5checksum* values for local files. If you are adding file locations via the bulk loader you must provide these or they will not be available.
+The *fileloc* table indicates where files can be downloaded. The *uri* column must contain the URI of the file. Even local files have a URI. For example a Drupal URI usually has a  *public://* URI prefix. For example: ```public://tripal/users/1/Citrus_sinensis-scaffold0.fasta```. When a file has more than one location to download the can be ordered by setting the *rank* column.  The Tripal file module automatically fills in the *size* and *md5checksum* values for local files. If you are adding file locations via the bulk loader you must provide these or the will not be available.
 
 +-------------+------------+------+---------------+---------------------------+
 | Column      | Type	   | Null | Default Value | Constraint                |

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -246,7 +246,7 @@ The *fileprop* table holds the properties or metadata about files. The CV term i
 
 The fileloc Table
 +++++++++++++++++
-The *fileloc* table indicates where files can be downloaded. The *uri* column must contain the URI of the file. Even local files have a URI. For example a Drupal URI usually has a  *public://* URI prefix. For example: ```public://tripal/users/1/Citrus_sinensis-scaffold0.fasta```. When a file has more than one location to download the can be ordered by setting the *rank* column.  The Tripal file module automatically fills in the *size* and *md5checksum* values for local files. If you are adding file locations via the bulk loader you must provide these or the will not be available.
+The *fileloc* table indicates where files can be downloaded. The *uri* column must contain the URI of the file. Even local files have a URI. For example a Drupal URI usually has a  *public://* URI prefix. For example: ```public://tripal/users/1/Citrus_sinensis-scaffold0.fasta```. When a file has more than one location to download the can be ordered by setting the *rank* column.  The Tripal file module automatically fills in the *size* and *md5checksum* values for local files. If you are adding file locations via the bulk loader you must provide these or they will not be available.
 
 +-------------+------------+------+---------------+---------------------------+
 | Column      | Type	   | Null | Default Value | Constraint                |

--- a/includes/TripalFields/sio__references_file/sio__references_file.inc
+++ b/includes/TripalFields/sio__references_file/sio__references_file.inc
@@ -198,13 +198,20 @@ class sio__references_file extends ChadoField {
           }
 
           // Add in the name and uniquename (identifier) if those fields exist.
+          // If name does not exist, e.g. for publication, use title
+          if (property_exists($record, 'uniquename')) {
+            $entity->{$field_name}['und'][$delta]['value']['data:0842'] = $record->uniquename;
+          }
           if (property_exists($record, 'name')) {
             $entity->{$field_name}['und'][$delta]['value']['schema:name'] = $record->name;
           }
-          if (property_exists($record, 'uniquename')) {
-            $entity->{$field_name}['und'][$delta]['value']['data:0842'] = $record->name;
+          else if (property_exists($record, 'title')) {
+            $entity->{$field_name}['und'][$delta]['value']['schema:name'] = $record->title;
           }
-
+          else {
+            // if we reach here, a new handler needs to be added, but for now add a placeholder
+            $entity->{$field_name}['und'][$delta]['value']['schema:name'] = 'Link';
+          }
 
           // If this is the organism table then we will create the name
           // specially.

--- a/includes/TripalFields/sio__references_file/sio__references_file.inc
+++ b/includes/TripalFields/sio__references_file/sio__references_file.inc
@@ -198,20 +198,13 @@ class sio__references_file extends ChadoField {
           }
 
           // Add in the name and uniquename (identifier) if those fields exist.
-          // If name does not exist, e.g. for publication, use title
-          if (property_exists($record, 'uniquename')) {
-            $entity->{$field_name}['und'][$delta]['value']['data:0842'] = $record->uniquename;
-          }
           if (property_exists($record, 'name')) {
             $entity->{$field_name}['und'][$delta]['value']['schema:name'] = $record->name;
           }
-          else if (property_exists($record, 'title')) {
-            $entity->{$field_name}['und'][$delta]['value']['schema:name'] = $record->title;
+          if (property_exists($record, 'uniquename')) {
+            $entity->{$field_name}['und'][$delta]['value']['data:0842'] = $record->name;
           }
-          else {
-            // if we reach here, a new handler needs to be added, but for now add a placeholder
-            $entity->{$field_name}['und'][$delta]['value']['schema:name'] = 'Link';
-          }
+
 
           // If this is the organism table then we will create the name
           // specially.


### PR DESCRIPTION
This corrects the issue of no reference appearing for a publication as described in issue #17, changes in the load() function.

There is also a correction to an error in setting the value for ```data:0842``` which should be ```uniquename``` instead of ```name```

I also added a default value in case this happens for some other content type in the future, at least there will be a clickable link.