### PR TITLE
Issue 25 skip if no info

### DIFF
--- a/tripal_file.module
+++ b/tripal_file.module
@@ -301,6 +301,9 @@ function tripal_file_bundle_fields_info_alter(&$info, $bundle, $term) {
  * Implements hook_bundle_fields_info_alter().
  */
 function tripal_file_bundle_instances_info_alter(&$info, $bundle, $term) {
+  if (!$info) {
+    return;
+  }
 
   if (array_key_exists('file_contact', $info)) {
     $info['file_contact']['label'] = 'File Source';


### PR DESCRIPTION
For issue #25 the fix here is to do nothing if ```$info``` is empty.
See also tripal issue https://github.com/tripal/tripal/issues/1370