### PR TITLE
issue 1 add file_relationship table

### DIFF
--- a/api/tripal_file.api.inc
+++ b/api/tripal_file.api.inc
@@ -12,3 +12,33 @@
  * Provides an application programming interface (API) for working with files
  * @}
  */
+
+/**
+ * Used for autocomplete in forms for identifying files
+ *
+ * @param $string
+ *   The string to search for.
+ *
+ * @return
+ *   A json array of terms that begin with the provided string.
+ *
+ * @ingroup tripal_file_api
+ */
+function chado_autocomplete_file($string = '') {
+  $items = [];
+  $sql = "
+    SELECT
+      F.file_id as id, F.name
+    FROM {file} F
+    WHERE lower(F.name) like lower(:str)
+    ORDER by F.name
+    LIMIT 25 OFFSET 0
+  ";
+  $records = chado_query($sql, [':str' => $string . '%']);
+  while ($r = $records->fetchObject()) {
+    $key = "$r->name [id: $r->id]";
+    $items[$key] = "$r->name";
+  }
+
+  drupal_json_output($items);
+}

--- a/tripal_file.install
+++ b/tripal_file.install
@@ -37,6 +37,7 @@ function tripal_file_install() {
   tripal_file_add_file_contact_table();
   tripal_file_add_fileloc_table();
   tripal_file_add_fileprop_table();
+  tripal_file_add_file_relationship_table();
   tripal_file_add_file_license_table();
   tripal_file_add_file_pub_table();
   tripal_file_add_linker_tables();
@@ -501,6 +502,58 @@ function tripal_file_add_fileprop_table(){
 /**
  *
  */
+function tripal_file_add_file_relationship_table(){
+  $schema = [
+    'table' => 'file_relationship',
+    'fields' => [
+      'file_relationship_id' => [
+        'type' => 'serial',
+        'not null' => TRUE
+      ],
+      'subject_id' => [
+        'type' => 'int',
+        'not null' => TRUE
+      ],
+      'object_id' => [
+        'type' => 'int',
+        'not null' => TRUE
+      ],
+      'type_id' => [
+        'type' => 'int',
+        'not null' => TRUE
+      ],
+    ],
+    'primary key' => ['file_relationship_id'],
+    'unique keys' => [
+      'file_relationship_c1' => ['subject_id', 'object_id', 'type_id'],
+    ],
+    'indexes' => [
+      'file_relationship_idx1' => ['subject_id'],
+      'file_relationship_idx2' => ['object_id'],
+      'file_relationship_idx3' => ['type_id'],
+    ],
+    'foreign keys' => [
+      'file' => [
+        'table' => 'file',
+        'columns' => [
+          'subject_id' => 'file_id',
+          'object_id' => 'file_id',
+        ],
+      ],
+      'cvterm' => [
+        'table' => 'cvterm',
+        'columns' => [
+          'type_id' => 'cvterm_id',
+        ],
+      ],
+    ],
+  ];
+  chado_create_custom_table('file_relationship', $schema, TRUE, NULL, FALSE);
+}
+
+/**
+ *
+ */
 function tripal_file_add_license_table(){
   $schema = [
     'table' => 'license',
@@ -846,4 +899,20 @@ function tripal_file_update_7102() {
     throw new DrupalUpdateException('Could not perform update: '. $error);
   }
 
+}
+
+/**
+ * Add the file_relationship table.
+ */
+function tripal_file_update_7103() {
+
+  $transaction = db_transaction();
+  try {
+    tripal_file_add_file_relationship_table();
+  }
+  catch (\PDOException $e) {
+    $transaction->rollback();
+    $error = $e->getMessage();
+    throw new DrupalUpdateException('Could not perform update: '. $error);
+  }
 }

--- a/tripal_file.module
+++ b/tripal_file.module
@@ -39,6 +39,15 @@ function tripal_file_menu() {
     'access arguments' => ['administer tripal'],
     'type' => MENU_LOCAL_TASK,
   ];
+  // Autocomplete for e.g. sbo__relationship widget.
+  $items['admin/tripal/storage/chado/auto_name/file/%'] = [
+    'page callback' => 'chado_autocomplete_file',
+    'page arguments' => [6],
+    'access arguments' => ['access content'],
+    'file' => 'api/tripal_file.api.inc',
+    'file path' => drupal_get_path('module', 'tripal_file'),
+    'type' => MENU_CALLBACK,
+  ];
 
   return $items;
 }


### PR DESCRIPTION
This pull request is for issue #1 
It adds a new chado custom table ```file_relationship``` and an autocomplete function.
This allows the ```sbo__relationship``` field to be used on file content types.

You will need to
1. run database updates
2. got to the file content type and click "+ Check for new fields". This should happen:
![sbo__relationship](https://user-images.githubusercontent.com/8419404/227730703-329ed0ba-5c09-4f4e-96b1-fcc7cd8fee4c.png)

An example of ```sbo__relationship``` in action
![examplerelationship](https://user-images.githubusercontent.com/8419404/227732422-0a212c7d-b17b-48b9-b388-da609dcf6177.png)

